### PR TITLE
Fix invalid state_class metadata for historical sensors

### DIFF
--- a/GridboxConnectorAddon-edge/GridboxConnector/models/models_historical.json
+++ b/GridboxConnectorAddon-edge/GridboxConnector/models/models_historical.json
@@ -96,7 +96,7 @@
             "device_class": "power_factor",
             "factor": 100,
             "unique_id": "direct_consumption_rate",
-            "state_class": "total",
+            "state_class": "measurement",
             "last_reset_value_template": "{{ value_json.last_reset }}",
             "value_template": "{{ value_json.state }}"
         },
@@ -126,7 +126,7 @@
             "device_class": "power_factor",
             "factor": 100,
             "unique_id": "self_consumption_rate",
-            "state_class": "total",
+            "state_class": "measurement",
             "last_reset_value_template": "{{ value_json.last_reset }}",
             "value_template": "{{ value_json.state }}"
         },
@@ -136,7 +136,7 @@
             "device_class": "power_factor",
             "factor": 100,
             "unique_id": "self_sufficiency_rate",
-            "state_class": "total",
+            "state_class": "measurement",
             "last_reset_value_template": "{{ value_json.last_reset }}",
             "value_template": "{{ value_json.state }}"
         },
@@ -158,7 +158,7 @@
             "device_class": "battery",
             "factor": 100,
             "unique_id": "battery_state_of_charge",
-            "state_class": "total",
+            "state_class": "measurement",
             "last_reset_value_template": "{{ value_json.last_reset }}",
             "value_template": "{{ value_json.state }}"
         },
@@ -168,7 +168,7 @@
             "device_class": "energy_storage",
             "factor": 1,
             "unique_id": "battery_capacity",
-            "state_class": "total",
+            "state_class": "measurement",
             "last_reset_value_template": "{{ value_json.last_reset }}",
             "value_template": "{{ value_json.state }}"
         },
@@ -178,7 +178,7 @@
             "device_class": "energy_storage",
             "factor": 1,
             "unique_id": "battery_power",
-            "state_class": "total",
+            "state_class": "measurement",
             "last_reset_value_template": "{{ value_json.last_reset }}",
             "value_template": "{{ value_json.state }}"
         },
@@ -188,7 +188,7 @@
             "device_class": "energy_storage",
             "factor": 1,
             "unique_id": "battery_remaining_charge",
-            "state_class": "total",
+            "state_class": "measurement",
             "last_reset_value_template": "{{ value_json.last_reset }}",
             "value_template": "{{ value_json.state }}"
         },
@@ -198,7 +198,7 @@
             "device_class": "energy_storage",
             "factor": 1,
             "unique_id": "battery_charge",
-            "state_class": "total",
+            "state_class": "measurement",
             "last_reset_value_template": "{{ value_json.last_reset }}",
             "value_template": "{{ value_json.state }}"
         },
@@ -208,7 +208,7 @@
             "device_class": "energy_storage",
             "factor": 1,
             "unique_id": "battery_discharge",
-            "state_class": "total",
+            "state_class": "measurement",
             "last_reset_value_template": "{{ value_json.last_reset }}",
             "value_template": "{{ value_json.state }}"
         }
@@ -230,7 +230,7 @@
             "device_class": "temperature",
             "factor": 1,
             "unique_id": "heater_temperature",
-            "state_class": "total",
+            "state_class": "measurement",
             "last_reset_value_template": "{{ value_json.last_reset }}",
             "value_template": "{{ value_json.state }}"
         }
@@ -252,7 +252,7 @@
             "device_class": "battery",
             "factor": 100,
             "unique_id": "ev_charging_station_state_of_charge",
-            "state_class": "total",
+            "state_class": "measurement",
             "last_reset_value_template": "{{ value_json.last_reset }}",
             "value_template": "{{ value_json.state }}"
         },
@@ -262,7 +262,7 @@
             "device_class": "current",
             "factor": 1,
             "unique_id": "ev_charging_station_current_l1",
-            "state_class": "total",
+            "state_class": "measurement",
             "last_reset_value_template": "{{ value_json.last_reset }}",
             "value_template": "{{ value_json.state }}"
         },
@@ -272,7 +272,7 @@
             "device_class": "current",
             "factor": 1,
             "unique_id": "ev_charging_station_current_l2",
-            "state_class": "total",
+            "state_class": "measurement",
             "last_reset_value_template": "{{ value_json.last_reset }}",
             "value_template": "{{ value_json.state }}"
         },
@@ -282,7 +282,7 @@
             "device_class": "current",
             "factor": 1,
             "unique_id": "ev_charging_station_current_l3",
-            "state_class": "total",
+            "state_class": "measurement",
             "last_reset_value_template": "{{ value_json.last_reset }}",
             "value_template": "{{ value_json.state }}"
         },


### PR DESCRIPTION
## Summary
This fixes invalid MQTT discovery metadata for historical sensors whose device classes do not support `state_class: total`.

## What changed
Updated the historical sensor models in the stable, edge, and dev addon variants so these sensors use `state_class: measurement` instead of `total`:

- `directConsumptionRate` (`power_factor`)
- `selfConsumptionRate` (`power_factor`)
- `selfSufficiencyRate` (`power_factor`)
- battery `stateOfCharge` (`battery`)
- battery `capacity` (`energy_storage`)
- battery `power` (`energy_storage`)
- battery `remainingCharge` (`energy_storage`)
- battery `charge` (`energy_storage`)
- battery `discharge` (`energy_storage`)
- heater `temperature` (`temperature`)
- EV charging station `stateOfCharge` (`battery`)
- EV charging station `currentL1` (`current`)
- EV charging station `currentL2` (`current`)
- EV charging station `currentL3` (`current`)

## Why
Home Assistant warns when MQTT sensors use `state_class: total` with device classes that only allow `measurement` (or no state class). The entities still work, but HA logs warnings for sensors such as:

- `sensor.viessmann_gridbox_historical_batterydischarge` with `device_class: energy_storage`
- `sensor.viessmann_gridbox_historical_batterystateofcharge` with `device_class: battery`
- `sensor.viessmann_gridbox_historical_directconsumptionrate` with `device_class: power_factor`
- `sensor.viessmann_gridbox_historical_selfconsumptionrate` with `device_class: power_factor`
- `sensor.viessmann_gridbox_historical_selfsufficiencyrate` with `device_class: power_factor`

This change keeps the historical energy totals unchanged while correcting the snapshot-style historical values to match Home Assistant's sensor semantics.

Partially addresses #224