### PR TITLE
Add missing live and historical sensors, fix heatPump casing

### DIFF
--- a/GridboxConnectorAddon-edge/GridboxConnector/models/models.json
+++ b/GridboxConnectorAddon-edge/GridboxConnector/models/models.json
@@ -84,12 +84,44 @@
       "factor": 100,
       "unique_id": "self_sufficiency_rate"
     },
-    "heatpump": {
+    "heatPump": {
       "name": "HeatPump",
       "unit": "W",
       "device_class": "power",
       "factor": 1,
       "unique_id": "heatpump"
+    },
+    "selfConsumption": {
+      "name": "SelfConsumption",
+      "unit": "W",
+      "device_class": "power",
+      "state_class": "measurement",
+      "factor": 1,
+      "unique_id": "self_consumption"
+    },
+    "directConsumptionHeater": {
+      "name": "DirectConsumptionHeater",
+      "unit": "W",
+      "device_class": "power",
+      "state_class": "measurement",
+      "factor": 1,
+      "unique_id": "direct_consumption_heater"
+    },
+    "gridMeterReadingNegative": {
+      "name": "GridMeterReadingNegative",
+      "unit": "Wh",
+      "device_class": "energy",
+      "state_class": "total_increasing",
+      "factor": 1,
+      "unique_id": "grid_meter_reading_negative"
+    },
+    "gridMeterReadingPositive": {
+      "name": "GridMeterReadingPositive",
+      "unit": "Wh",
+      "device_class": "energy",
+      "state_class": "total_increasing",
+      "factor": 1,
+      "unique_id": "grid_meter_reading_positive"
     }
   },
   "battery": {

--- a/GridboxConnectorAddon-edge/GridboxConnector/models/models_historical.json
+++ b/GridboxConnectorAddon-edge/GridboxConnector/models/models_historical.json
@@ -149,6 +149,26 @@
             "state_class": "total",
             "last_reset_value_template": "{{ value_json.last_reset }}",
             "value_template": "{{ value_json.state }}"
+        },
+        "selfConsumption": {
+            "name": "SelfConsumption",
+            "unit": "Wh",
+            "device_class": "energy",
+            "factor": 1,
+            "unique_id": "self_consumption",
+            "state_class": "total",
+            "last_reset_value_template": "{{ value_json.last_reset }}",
+            "value_template": "{{ value_json.state }}"
+        },
+        "directConsumptionHeater": {
+            "name": "DirectConsumptionHeater",
+            "unit": "Wh",
+            "device_class": "energy",
+            "factor": 1,
+            "unique_id": "direct_consumption_heater",
+            "state_class": "total",
+            "last_reset_value_template": "{{ value_json.last_reset }}",
+            "value_template": "{{ value_json.state }}"
         }
     },
     "battery": {


### PR DESCRIPTION
## Summary
Add sensors for API fields that are returned but not yet exposed via MQTT,
and fix a casing bug that prevented the aggregate heatPump sensor from working.

### Bug fix
- `heatpump` → `heatPump`: the API returns `heatPump` (camelCase) but
  the model used `heatpump` (lowercase). The case-sensitive key lookup
  meant this sensor was never created despite being defined.

### New live sensors
- `selfConsumption` (W) — total self-consumed PV power
- `directConsumptionHeater` (W) — heater direct consumption
- `gridMeterReadingNegative` (Wh, total_increasing) — cumulative grid export meter
- `gridMeterReadingPositive` (Wh, total_increasing) — cumulative grid import meter

### New historical sensors
- `selfConsumption` (Wh)
- `directConsumptionHeater` (Wh)

All new sensors include proper `state_class` metadata.